### PR TITLE
Fixed hi function on cpu.c that returns always 0.

### DIFF
--- a/src/cpu.c
+++ b/src/cpu.c
@@ -43,7 +43,7 @@ uint8_t lo(uint16_t address)
 }
 uint8_t hi(uint16_t address)
 {
-    return (uint8_t)address >> 8;
+    return (uint8_t)(address >> 8);
 }
 uint16_t fetch()
 {


### PR DESCRIPTION
`hi` on cpu.c function is currently returning always 0 due to the higher precedence of the casting from uint16_t to the uint8_t than the bit shifting operation. Adding parenthesis surrounding the shift operation fixes the issue.